### PR TITLE
Cocoapods 1.X compatability

### DIFF
--- a/ZappSMGLib.podspec
+++ b/ZappSMGLib.podspec
@@ -8,6 +8,7 @@ s.description  = <<-DESC
 Zapp Small Merchant Library
 DESC
 
+s.source       = "https://github.com/mwfire/ZappSMGLib-iOS"
 s.homepage     = "http://zapp.co.uk"
 s.license      = "Apache License, Version 2.0"
 

--- a/ZappSMGLib.podspec
+++ b/ZappSMGLib.podspec
@@ -8,7 +8,7 @@ s.description  = <<-DESC
 Zapp Small Merchant Library
 DESC
 
-s.source       = "https://github.com/mwfire/ZappSMGLib-iOS"
+s.source       = { :git => 'https://github.com/vocalinkzapp/ZappSMGLib-iOS', :tag => s.version.to_s }
 s.homepage     = "http://zapp.co.uk"
 s.license      = "Apache License, Version 2.0"
 

--- a/ZappSMGLibObjC.podspec
+++ b/ZappSMGLibObjC.podspec
@@ -8,6 +8,7 @@ s.description  = <<-DESC
 Zapp Small Merchant Library
 DESC
 
+s.source       = "https://github.com/mwfire/ZappSMGLib-iOS"
 s.homepage     = "http://zapp.co.uk"
 s.license      = "Apache License, Version 2.0"
 

--- a/ZappSMGLibObjC.podspec
+++ b/ZappSMGLibObjC.podspec
@@ -8,7 +8,8 @@ s.description  = <<-DESC
 Zapp Small Merchant Library
 DESC
 
-s.source       = "https://github.com/mwfire/ZappSMGLib-iOS"
+
+s.source       = { :git => 'https://github.com/vocalinkzapp/ZappSMGLib-iOS', :tag => s.version.to_s }
 s.homepage     = "http://zapp.co.uk"
 s.license      = "Apache License, Version 2.0"
 


### PR DESCRIPTION
Cocoapods 1 requires `source` to be defined in the .podspec, otherwise pod installation fails. Maybe it's worth implementing this still :)